### PR TITLE
Add PHP 8.0 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,9 +16,9 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.2|^8.0",
         "illuminate/support": "*",
-        "barryvdh/laravel-dompdf": "^0.8.6",
+        "barryvdh/laravel-dompdf": "^0.9.0",
         "guzzlehttp/guzzle": "^7"
     },
     "require-dev": {


### PR DESCRIPTION
This MR adds support for PHP 8.

In order to do this, an update to "barryvdh/laravel-dompdf" v0.9.0 has been necessary.
The update doesn't break any functionality and the tests pass.