### PR TITLE
[WIP] Allow Tasks and Triggers to define their translations

### DIFF
--- a/resources/views/diagram.blade.php
+++ b/resources/views/diagram.blade.php
@@ -52,7 +52,7 @@
     <div class="col">
         @foreach(config('workflows.triggers.types') as $taskName => $taskClass)
             <div class="drag-drawflow" draggable="true" ondragstart="drag(event)" data-node="{{ $taskName }}">
-                {!! $taskClass::$icon !!}<span> {{ __('workflows::workflows.Elements.'.$taskName) }}</span>
+                {!! $taskClass::$icon !!}<span> {{$taskClass::getTranslation() }}</span>
             </div>
         @endforeach
         @foreach(config('workflows.tasks') as $taskName => $taskClass)
@@ -90,19 +90,20 @@
     const editor = new Drawflow(id);
     editor.start();
 
-        @foreach($workflow->tasks as $task)
-    var new_node = `@include('workflows::layouts.task_node_html', ['elementName' => $task->name, 'element' => $task, 'type' => 'task', 'icon' => $task::$icon])`;
-    editor.addNode(0, '{{ $task->name }}', 1, 1, {{$task->pos_x}}, {{ $task->pos_y }}, '{{ $task->name }}', {
-        task_id: {{$task->id}},
-        type: 'task'
-    }, new_node);
-        @endforeach
-        @foreach($workflow->triggers as $trigger)
-    var new_node = `@include('workflows::layouts.task_node_html', ['elementName' => $trigger->name, 'element' => $trigger, 'type' => 'trigger', 'icon' => $trigger::$icon])`;
-    editor.addNode(0, '{{ $trigger->name }}', 0, 1, {{$trigger->pos_x}}, {{ $trigger->pos_y }}, '{{ $trigger->name }}', {
-        trigger_id: {{$trigger->id}},
-        type: 'trigger'
-    }, new_node);
+    @foreach($workflow->tasks as $task)
+        var new_node = `@include('workflows::layouts.task_node_html', ['elementName' => $task->getTranslation(), 'element' => $task, 'type' => 'task', 'icon' => $task::$icon])`;
+        editor.addNode(0, '{{ $task->name }}', 1, 1, {{$task->pos_x}}, {{ $task->pos_y }}, '{{ $task->name }}', {
+            task_id: {{$task->id}},
+            type: 'task'
+        }, new_node);
+    @endforeach
+
+    @foreach($workflow->triggers as $trigger)
+        var new_node = `@include('workflows::layouts.task_node_html', ['elementName' => $trigger->getTranslation(), 'element' => $trigger, 'type' => 'trigger', 'icon' => $trigger::$icon])`;
+        editor.addNode(0, '{{ $trigger->name }}', 0, 1, {{$trigger->pos_x}}, {{ $trigger->pos_y }}, '{{ $trigger->name }}', {
+            trigger_id: {{$trigger->id}},
+            type: 'trigger'
+        }, new_node);
 
     @endforeach
 
@@ -377,13 +378,13 @@
         switch (name) {
             @foreach(config('workflows.tasks') as $taskName => $taskClass)
             case '{{ $taskName }}':
-                var {{$taskName}}_new_node = `@include('workflows::layouts.task_node_html', ['elementName' => $taskName, 'fields' => $taskClass::$fields, 'type' => 'task', 'icon' => $taskClass::$icon])`;
+                var {{$taskName}}_new_node = `@include('workflows::layouts.task_node_html', ['elementName' => $taskClass::getTranslation(), 'fields' => $taskClass::$fields, 'type' => 'task', 'icon' => $taskClass::$icon])`;
                 editor.addNode(0, '{{ $taskName }}', 1, 1, pos_x, pos_y, '{{ $taskName }}', {type: 'task'}, {{$taskName}}_new_node);
                 break;
             @endforeach
             @foreach(config('workflows.triggers.types') as $triggerName => $triggerClass)
             case '{{$triggerName}}':
-                var {{$taskName}}_new_node = `@include('workflows::layouts.task_node_html', ['elementName' => $triggerName, 'fields' => $triggerClass::$fields, 'type' => 'trigger', 'icon' => $triggerClass::$icon])`;
+                var {{$taskName}}_new_node = `@include('workflows::layouts.task_node_html', ['elementName' => $triggerClass::getTranslation(), 'fields' => $triggerClass::$fields, 'type' => 'trigger', 'icon' => $triggerClass::$icon])`;
                 editor.addNode(0, '{{$triggerName}}', 0, 1, pos_x, pos_y, '{{$triggerName}}', {type: 'trigger'}, {{$taskName}}_new_node);
                 break;
             @endforeach

--- a/resources/views/layouts/conditions_overlay.blade.php
+++ b/resources/views/layouts/conditions_overlay.blade.php
@@ -3,7 +3,7 @@
         <div class="row">
             <div class="col-md-12" style="margin-bottom: 20px;">
                 <div class="settings-headline">
-                    <h1>{!! $element::$icon !!} {{__('workflows::workflows.Elements.'.$element->name) }} {{__('workflows::workflows.Settings') }}</h1>
+                    <h1>{!! $element::$icon !!} {{ $element::getTranslation()  }} {{__('workflows::workflows.Settings') }}</h1>
                 </div>
             </div>
             <div class="col-md-12">

--- a/resources/views/layouts/settings_overlay.blade.php
+++ b/resources/views/layouts/settings_overlay.blade.php
@@ -3,7 +3,7 @@
         <div class="row">
             <div class="col-md-12" style="margin-bottom: 20px;">
                 <div class="settings-headline">
-                    <h1>{!! $element::$icon !!} {{__('workflows::workflows.Elements.'.$element->name) }} {{__('workflows::workflows.Settings') }}</h1>
+                    <h1>{!! $element::$icon !!} {{ $element::getTranslation()  }} {{__('workflows::workflows.Settings') }}</h1>
                 </div>
             </div>
             <div class="col-md-12">

--- a/resources/views/layouts/task_node_html.blade.php
+++ b/resources/views/layouts/task_node_html.blade.php
@@ -1,6 +1,6 @@
 <div>
     <div class="title-box">
-        {!! $icon !!} {{ __('workflows::workflows.Elements.'.$elementName) }}
+        {!! $icon !!} {{ $elementName }}
     </div>
     <div class="box">
         {{ $element->data_fields['description']['value'] ?? '' }}

--- a/src/Tasks/Task.php
+++ b/src/Tasks/Task.php
@@ -183,4 +183,16 @@ class Task extends Model implements TaskInterface
             'element' => $this,
         ]);
     }
+
+    public static function getTranslation(): string
+    {
+        return __(static::getTranslationKey());
+    }
+
+    public static function getTranslationKey(): string
+    {
+        $className = (new \ReflectionClass(new static))->getShortName();
+
+        return "workflows::workflows.Elements.{$className}";
+    }
 }

--- a/src/Triggers/Trigger.php
+++ b/src/Triggers/Trigger.php
@@ -94,4 +94,16 @@ class Trigger extends Model
             'element' => $this,
         ]);
     }
+
+    public static function getTranslation(): string
+    {
+        return __(static::getTranslationKey());
+    }
+
+    public static function getTranslationKey(): string
+    {
+        $className = (new \ReflectionClass(new static))->getShortName();
+
+        return "workflows::workflows.Elements.{$className}";
+    }
 }


### PR DESCRIPTION
This merge request allow Tasks and Triggers to define their translations for themselves, instead of pulling them from the config file.

The default is still following the convention used within the package.

This allows 3rd party plugins/packages to add new triggers/tasks more easily.